### PR TITLE
Add note about Node 6.3 to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Steemit
 #### Install dependencies
 
 ```bash
+# Install at least Node v6.3 if you don't already have it (NVM recommended)
+nvm install v6
+
 npm install
 npm install -g babel-cli
 ```


### PR DESCRIPTION
It's not stated anywhere on the README, so I added it to the dependencies, and suggested nvm (which is pretty important for anyone who works on more than one node project)